### PR TITLE
docs: update dev plan with recent requirement clarifications

### DIFF
--- a/projects/jobtrackr/DEVELOPMENT_PLAN.md
+++ b/projects/jobtrackr/DEVELOPMENT_PLAN.md
@@ -30,14 +30,22 @@ Build and ship the current AI-powered app initiative quickly with clean, maintai
 - Break the finalized parser and ingestion contract changes into implementation-ready tickets after the jobs dashboard payload is locked
 
 ## Decisions & Notes
-- Keep task ownership explicit to avoid duplicate work across engineer agents.
+- Keep task ownership explicit to avoid duplicate work across SWE agents.
 - Branch naming should track the task focus and remain one task per branch.
 - Gmail integration for the new job search project will use Gmail API with local web OAuth flow and env-based secrets, not embedded credentials.
 - Gmail access remains Gmail readonly scope only for MVP.
+- Google auth policy: allow anyone with a Google account to sign in (not single approved account only).
 - The first Alice vertical slice is auth, protected shell, Gmail connection, and raw source-email ingestion before fit analysis.
 - Initial sync defaults to the last 30 days, with future work planned around a 10 minute incremental sync plus manual refresh.
 - Frank is owning the dependency map and milestone sequencing pass to identify blockers before Milestones 1 through 4 proceed in parallel.
 - Marcus is owning the jobs dashboard contract shape so frontend and API work can converge on the same table payload, especially around match rating and flagged semantics.
+- Job enrichment: scrape full details from job detail page linked in email.
+- Deduplication: match on job URL to merge repeated alerts for the same job.
+- Mandatory job record fields: id, title, company, description, salary range, location, match (1-100), skills, tags.
+- Fit display: show match score from 1 to 100.
+- Auto-close: jobs with match score below 60 are automatically set to "not a match" status.
+- Notifications: no email/push notifications; user reviews jobs in UI.
+- Status model: new, flagged, reviewing, skipped, not a match, applied, interview, rejected, offer.
 
 ## Branch & PR Rules
 - Branch naming: `feat/<short-desc>`, `fix/<short-desc>`, `chore/<short-desc>`


### PR DESCRIPTION
- Update agent references from 'engineer' to 'SWE'
- Add Google auth policy decision (allow anyone with Google account)
- Add job enrichment method (scrape from job detail page)
- Add deduplication logic (match on job URL)
- Add mandatory job record fields
- Add fit display method (score 1-100)
- Add auto-close feature (jobs below 60 score set to 'not a match')
- Add notification policy (no notifications, review in UI)
- Update status model to include 'not a match'